### PR TITLE
Switching v2 to v3 Twitch http header

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -291,7 +291,7 @@ function importFollowers(name, offset, added) {
 }
 
 popup.port.on("popout_chat", function(name) {
-	url = "http://www.twitch.tv/chat/embed?channel="+name+"&popout_chat=true";
+	url = "https://www.twitch.tv/chat/embed?channel="+name+"&popout_chat=true";
 	tabs.open(url);
 //	var window = open(url, {
 //		name: name + " - Twitch Chat",

--- a/lib/twitchAPI.js
+++ b/lib/twitchAPI.js
@@ -11,7 +11,7 @@ exports.getFollowedChannels = getFollowedChannels;
 exports.getCurrentStreams = getCurrentStreams;
 
 var httpHeaders = {
-	'Accept': "application/vnd.twitchtv.v2+json",
+	'Accept': "application/vnd.twitchtv.v3+json",
 	'Client-ID': "t163mfex6sggtq6ogh0fo8qcy9ybpd6"
 };
 	


### PR DESCRIPTION
Add-on not working anymore due to Twitch API v2 not supported anymore (410 Gone http response).